### PR TITLE
Fix task for new build agent.

### DIFF
--- a/VSTS-Extensions/VSTSToolsKeep/keepbuild.ps1
+++ b/VSTS-Extensions/VSTSToolsKeep/keepbuild.ps1
@@ -14,7 +14,7 @@ if ($debugonly -eq "false" -or (($debugonly -eq "true") -and ($env:SYSTEM_DEBUG 
 {
     if ($env:BUILD_SOURCEBRANCHNAME -eq $targetbranch)
     {
-        $uri = "$($env:SYSTEM_TEAMFOUNDATIONSERVERURI)$env:SYSTEM_TEAMPROJECT/_apis/build/builds/$($env:BUILD_BUILDID)?api-version=2.0"
+        $uri = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$env:SYSTEM_TEAMPROJECT/_apis/build/builds/$($env:BUILD_BUILDID)?api-version=2.0"
         Write-Verbose "URI: $uri"
         
         $body = "{keepForever:true}"

--- a/VSTS-Extensions/VSTSToolsKeep/task.json
+++ b/VSTS-Extensions/VSTSToolsKeep/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": "1",
     "Minor": "0",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "1.99.0",
   "instanceNameFormat": "VSTS-Tools Keep $(message)",


### PR DESCRIPTION
SYSTEM_TEAMFOUNDATIONSERVERURI doesn't seem to be available in the new build agent. Use SYSTEM_TEAMFOUNDATIONCOLLECTIONURI instead.

Fixes #6