### PR TITLE
add more helpful error message to VSTS-Keep's System.Net.WebException

### DIFF
--- a/VSTS-Keep/Program.cs
+++ b/VSTS-Keep/Program.cs
@@ -18,12 +18,14 @@ namespace VSTSKeep
             {
                 // Add the verbose switch programmatically because I am having issues with the attributes
                 var verbose = new SwitchArgument('v', "verbose", "Turns on verbose output.", false);
-                var keepForever = new SwitchArgument('k', "keep", "If specified, sets to \"Keep Forever\"; Otherwise, removes the flag.", false);
+                var keepForever = new SwitchArgument('k', "keep",
+                    "If specified, sets to \"Keep Forever\"; Otherwise, removes the flag.", false);
 
                 parser.Arguments.Add(verbose);
                 parser.Arguments.Add(keepForever);
 
-                parser.ShowUsageHeader = "Sets or removes \"keep forever\" retention for the specified build number in VSTS.\r\n\r\n" +
+                parser.ShowUsageHeader =
+                    "Sets or removes \"keep forever\" retention for the specified build number in VSTS.\r\n\r\n" +
                     "VSTS-KEEP -a <Account> [-u <User ID>] -p <Password> -t <Project> -b <BuildNumber> [-k]";
                 parser.ShowUsageOnEmptyCommandline = true;
 
@@ -32,7 +34,8 @@ namespace VSTSKeep
 
                 if (parser.ParsingSucceeded)
                 {
-                    var authentication = new BasicAuthentication(cmdLineArgs.Account, cmdLineArgs.UserId, cmdLineArgs.Password);
+                    var authentication =
+                        new BasicAuthentication(cmdLineArgs.Account, cmdLineArgs.UserId, cmdLineArgs.Password);
                     var helper = new VstsHelper();
 
                     Console.WriteLine(helper.KeepForever(authentication, cmdLineArgs.Project, cmdLineArgs.BuildNumber,
@@ -40,6 +43,16 @@ namespace VSTSKeep
                         ? "    Retention set successfully."
                         : "    Failed to set retention.");
                 }
+            }
+            catch (System.Net.WebException ex)
+            {
+                Console.WriteLine(ex.Message);
+                if (ex.Message.Contains("(401) Unauthorized."))
+                {
+                    Console.WriteLine("VSTS-Keep requires access to the account's OAuth token in order to correctly set the keep forever config.");
+                    Console.WriteLine("Please go to this build definition's options tab and enable build scripts to access the OAuth token.");
+                }
+                parser.ShowUsage();
             }
             catch (Exception ex)
             {

--- a/VSTS-Keep/Program.cs
+++ b/VSTS-Keep/Program.cs
@@ -18,14 +18,12 @@ namespace VSTSKeep
             {
                 // Add the verbose switch programmatically because I am having issues with the attributes
                 var verbose = new SwitchArgument('v', "verbose", "Turns on verbose output.", false);
-                var keepForever = new SwitchArgument('k', "keep",
-                    "If specified, sets to \"Keep Forever\"; Otherwise, removes the flag.", false);
+                var keepForever = new SwitchArgument('k', "keep", "If specified, sets to \"Keep Forever\"; Otherwise, removes the flag.", false);
 
                 parser.Arguments.Add(verbose);
                 parser.Arguments.Add(keepForever);
 
-                parser.ShowUsageHeader =
-                    "Sets or removes \"keep forever\" retention for the specified build number in VSTS.\r\n\r\n" +
+                parser.ShowUsageHeader = "Sets or removes \"keep forever\" retention for the specified build number in VSTS.\r\n\r\n" +
                     "VSTS-KEEP -a <Account> [-u <User ID>] -p <Password> -t <Project> -b <BuildNumber> [-k]";
                 parser.ShowUsageOnEmptyCommandline = true;
 
@@ -34,8 +32,7 @@ namespace VSTSKeep
 
                 if (parser.ParsingSucceeded)
                 {
-                    var authentication =
-                        new BasicAuthentication(cmdLineArgs.Account, cmdLineArgs.UserId, cmdLineArgs.Password);
+                    var authentication = new BasicAuthentication(cmdLineArgs.Account, cmdLineArgs.UserId, cmdLineArgs.Password);
                     var helper = new VstsHelper();
 
                     Console.WriteLine(helper.KeepForever(authentication, cmdLineArgs.Project, cmdLineArgs.BuildNumber,


### PR DESCRIPTION
Ran into this issue when I added this task to a task group that many build definitions used. It began failing the build for only some of them, as most already had enabled scripts to access the OAuth token. I wanted to make this experience better for the next dev to run into the issue, so here I have added a more helpful error message.