### PR TITLE
Upgrade powershell execution handler

### DIFF
--- a/VSTS-Extensions/Test/VSTSToolsListVariables/sample.js
+++ b/VSTS-Extensions/Test/VSTSToolsListVariables/sample.js
@@ -1,0 +1,23 @@
+var path = require('path');
+var tl = require('vso-task-lib');
+
+var echo = new tl.ToolRunner(tl.which('echo', true));
+
+var msg = tl.getInput('msg', true);
+echo.arg(msg);
+
+var cwd = tl.getPathInput('cwd', false);
+
+// will error and fail task if it doesn't exist
+tl.checkPath(cwd, 'cwd');
+tl.cd(cwd);
+
+echo.exec({ failOnStdErr: false})
+.then(function(code) {
+    tl.exit(code);
+})
+.fail(function(err) {
+    console.error(err.message);
+    tl.debug('taskRunner fail');
+    tl.exit(1);
+})

--- a/VSTS-Extensions/Test/VSTSToolsListVariables/sample.ps1
+++ b/VSTS-Extensions/Test/VSTSToolsListVariables/sample.ps1
@@ -1,0 +1,30 @@
+param (
+    [string]$cwd,
+    [string]$msg
+)
+
+Write-Verbose 'Entering sample.ps1'
+Write-Verbose "cwd = $cwd"
+Write-Verbose "msg = $msg"
+
+# Import the Task.Common dll that has all the cmdlets we need for Build
+import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
+
+if(!$cwd)
+{
+    throw (Get-LocalizedString -Key "Working directory parameter is not set")
+}
+
+if(!(Test-Path $cwd -PathType Container))
+{
+    throw ("$cwd does not exist");
+}
+
+Write-Verbose "Setting working directory to $cwd"
+Set-Location $cwd
+
+Write-Host $msg
+
+
+
+

--- a/VSTS-Extensions/Test/VSTSToolsListVariables/sample.ps1
+++ b/VSTS-Extensions/Test/VSTSToolsListVariables/sample.ps1
@@ -1,7 +1,5 @@
-param (
-    [string]$cwd,
-    [string]$msg
-)
+[string]$cwd = $env:INPUT_CWD
+[string]$msg = $env:INPUT_MSG
 
 Write-Verbose 'Entering sample.ps1'
 Write-Verbose "cwd = $cwd"

--- a/VSTS-Extensions/Test/VSTSToolsListVariables/task.json
+++ b/VSTS-Extensions/Test/VSTSToolsListVariables/task.json
@@ -41,7 +41,7 @@
       "target": "sample.js",
       "argumentFormat": ""
     },
-    "PowerShell": {
+    "PowerShell3": {
       "target": "$(currentDirectory)\\sample.ps1",
       "argumentFormat": "",
       "workingDirectory": "$(currentDirectory)"

--- a/VSTS-Extensions/VSTSToolsComments/comments.ps1
+++ b/VSTS-Extensions/VSTSToolsComments/comments.ps1
@@ -1,0 +1,20 @@
+param (
+    [string]$comments,
+    [string]$includeCommentsInLog
+)
+
+Write-Verbose "Entering: comments.ps1"
+Write-Verbose "  comments: $comments"
+Write-Verbose "  includeCommentsInLog: $includeCommentsInLog"
+
+# Import the Task.Common dll that has all the cmdlets we need for Build
+import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
+
+if ($includeCommentsInLog -eq "true")
+{
+  Write-Output " "
+  Write-Output "Comments"
+  Write-Output "--------"
+  Write-Output("{0}" -f $comments)
+  Write-Output " "
+}

--- a/VSTS-Extensions/VSTSToolsComments/comments.ps1
+++ b/VSTS-Extensions/VSTSToolsComments/comments.ps1
@@ -1,7 +1,5 @@
-param (
-    [string]$comments,
-    [string]$includeCommentsInLog
-)
+[string]$comments = $env:INPUT_COMMENTS
+[string]$includeCommentsInLog = $env:INPUT_INCLUDECOMMENTSINLOG
 
 Write-Verbose "Entering: comments.ps1"
 Write-Verbose "  comments: $comments"

--- a/VSTS-Extensions/VSTSToolsComments/task.json
+++ b/VSTS-Extensions/VSTSToolsComments/task.json
@@ -41,7 +41,7 @@
     }
   ],
   "execution": {
-    "PowerShell": {
+    "PowerShell3": {
       "target": "$(currentDirectory)\\comments.ps1",
       "argumentFormat": "",
       "workingDirectory": "$(currentDirectory)"

--- a/VSTS-Extensions/VSTSToolsKeep/keepbuild.ps1
+++ b/VSTS-Extensions/VSTSToolsKeep/keepbuild.ps1
@@ -1,7 +1,5 @@
-param (
-    [string]$targetbranch,
-    [string]$debugonly
-)
+[string]$targetbranch = $env:INPUT_TARGETBRANCH
+[string]$debugonly = $env:INPUT_DEBUGONLY
 
 Write-Verbose "Entering: keepbuild.ps1"
 Write-Verbose "  targetbranch: $targetbranch"

--- a/VSTS-Extensions/VSTSToolsKeep/task.json
+++ b/VSTS-Extensions/VSTSToolsKeep/task.json
@@ -45,7 +45,7 @@
     }
   ],
   "execution": {
-    "PowerShell": {
+    "PowerShell3": {
       "target": "$(currentDirectory)\\keepbuild.ps1",
       "argumentFormat": "",
       "workingDirectory": "$(currentDirectory)"

--- a/VSTS-Extensions/VSTSToolsListApps/listapps.ps1
+++ b/VSTS-Extensions/VSTSToolsListApps/listapps.ps1
@@ -1,0 +1,28 @@
+param (
+    [string]$debugonly
+)
+
+Write-Verbose "Entering: listapps.ps1"
+Write-Verbose "  debugonly: $debugonly"
+
+# Import the Task.Common dll that has all the cmdlets we need for Build
+import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
+
+if ($debugonly -eq "false" -or (($debugonly -eq "true") -and ($env:SYSTEM_DEBUG -eq "true")))
+{
+  Function IIf($If, $Right, $Wrong) {If ($If) {$Right} Else {$Wrong}}
+
+  Write-Output " "
+  Write-Output "Installed Applications"
+  Write-Output "----------------------"
+  $children = Get-ChildItem -Path HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall |
+     Get-ItemProperty |
+     Where-Object {$_.DisplayName -ne $null} |
+     Sort-Object -Property DisplayName |
+     Select-Object -Property DisplayName, DisplayVersion, InstallDate, EstimatedSize, Publisher, "---------------------"
+
+  $count = 0
+  $children | ForEach-Object {$count = $count + 1; Write-Output("{0} [{1}]" -f $_.DisplayName, (IIf ($_.DisplayVersion -eq $null) "No Version Information" $_.DisplayVersion))}
+  Write-Output "--------------------------"
+  Write-Output("{0} applications installed." -f $count)
+}

--- a/VSTS-Extensions/VSTSToolsListApps/listapps.ps1
+++ b/VSTS-Extensions/VSTSToolsListApps/listapps.ps1
@@ -1,6 +1,4 @@
-param (
-    [string]$debugonly
-)
+[string]$debugonly = $env:INPUT_DEBUGONLY
 
 Write-Verbose "Entering: listapps.ps1"
 Write-Verbose "  debugonly: $debugonly"

--- a/VSTS-Extensions/VSTSToolsListApps/task.json
+++ b/VSTS-Extensions/VSTSToolsListApps/task.json
@@ -37,7 +37,7 @@
     }
   ],
   "execution": {
-    "PowerShell": {
+    "PowerShell3": {
       "target": "$(currentDirectory)\\listapps.ps1",
       "argumentFormat": "",
       "workingDirectory": "$(currentDirectory)"

--- a/VSTS-Extensions/VSTSToolsListFiles/listfiles.ps1
+++ b/VSTS-Extensions/VSTSToolsListFiles/listfiles.ps1
@@ -1,7 +1,5 @@
-param (
-    [string]$rootdir,
-    [string]$debugonly
-)
+[string]$rootdir = $env:INPUT_ROOTDIR
+[string]$debugonly = $env:INPUT_DEBUGONLY
 
 Write-Verbose "Entering: listfiles.ps1"
 Write-Verbose "  rootdir = $rootdir"

--- a/VSTS-Extensions/VSTSToolsListFiles/listfiles.ps1
+++ b/VSTS-Extensions/VSTSToolsListFiles/listfiles.ps1
@@ -1,0 +1,23 @@
+param (
+    [string]$rootdir,
+    [string]$debugonly
+)
+
+Write-Verbose "Entering: listfiles.ps1"
+Write-Verbose "  rootdir = $rootdir"
+Write-Verbose "  debugonly = $debugonly"
+
+# Import the Task.Common dll that has all the cmdlets we need for Build
+import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
+
+if(!$rootdir)
+{
+    $rootdir = ".";
+}
+
+Write-Verbose "Setting root directory to $rootdir"
+
+if ($debugonly -eq "false" -or (($debugonly -eq "true") -and ($env:SYSTEM_DEBUG -eq "true")))
+{
+    dir $rootdir -r  | % { if ($_.PsIsContainer) { $_.FullName + "\" } else { $_.FullName } }
+}

--- a/VSTS-Extensions/VSTSToolsListFiles/task.json
+++ b/VSTS-Extensions/VSTSToolsListFiles/task.json
@@ -45,7 +45,7 @@
     }
   ],
   "execution": {
-    "PowerShell": {
+    "PowerShell3": {
       "target": "$(currentDirectory)\\listfiles.ps1",
       "argumentFormat": "",
       "workingDirectory": "$(currentDirectory)"

--- a/VSTS-Extensions/VSTSToolsListSystemInfo/listsysteminfo.ps1
+++ b/VSTS-Extensions/VSTSToolsListSystemInfo/listsysteminfo.ps1
@@ -1,0 +1,73 @@
+param (
+    [string]$debugonly
+)
+
+Write-Verbose "Entering: listsysteminfo.ps1"
+Write-Verbose "  debugonly: $debugonly"
+
+# Import the Task.Common dll that has all the cmdlets we need for Build
+import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
+
+if ($debugonly -eq "false" -or (($debugonly -eq "true") -and ($env:SYSTEM_DEBUG -eq "true")))
+{
+  $result = gwmi Win32_OperatingSystem 
+  $system = get-wmiobject Win32_ComputerSystem
+  $timeZoneInfo = [TimeZoneInfo]::Local
+  $OSInfo = Get-WmiObject Win32_OperatingSystem
+
+  Write-Output(" ")
+  Write-Output("SERVER")
+  Write-Output("------")
+  Write-Output("Computer Name:                 $($result.PSComputerName)")
+  Write-Output("Manufacturer:                  $($system.Manufacturer)")
+  Write-Output("Model:                         $($system.Model)")
+  Write-Output("# of Processors:               $($system.NumberOfProcessors)")
+  Write-Output("# of Logical Processors:       $($system.NumberOfLogicalProcessors)")
+
+  Write-Output(" ")
+  Write-Output("OPERATING SYSTEM")
+  Write-Output("----------------")
+  Write-Output("Operating System:              $($result.Caption)")
+  Write-Output("Operating System Version:      $($result.Version)")
+  Write-Output("OS Service Pack Version:       {0}.{1}" -f $result.ServicePackMajorVersion, $result.ServicePackMinorVersion)
+  Write-Output("OS Install Date:               {0}" -f ([WMI]'').ConvertToDateTime($OSInfo.InstallDate))
+  Write-Output("Last Bootup Time:              {0}" -f ([WMI]'').ConvertToDateTime($OSInfo.LastBootUpTime))
+  Write-Output("OS Language:                   $($result.OSLanguage)")
+  Write-Output("Locale:                        $($result.Locale)")
+  Write-Output("System Directory:              $($result.SystemDirectory)")
+  Write-Output("Windows Directory:             $($result.WindowsDirectory)")
+
+  Write-Output(" ")
+  Write-Output("TIME ZONE INFORMATION")
+  Write-Output("---------------------")
+  Write-Output("ID:                            $($timeZoneInfo.Id)")
+  Write-Output("DisplayName:                   $($timeZoneInfo.DisplayName)")
+  Write-Output("StandardName:                  $($timeZoneInfo.StandardName)")
+  Write-Output("DaylightName:                  $($timeZoneInfo.DaylightName)")
+  Write-Output("BaseUtcOffset:                 $($timeZoneInfo.BaseUtcOffset)")
+  Write-Output("Supports Daylight Saving Time: $($timeZoneInfo.SupportsDaylightSavingTime)")
+
+  Write-Output(" ")
+  Write-Output("SYSTEM MEMORY")
+  Write-Output("-------------")
+  Write-Output("Total Memory:                  {0:###,###,###,###.0} GB" -f ($result.TotalVisibleMemorySize / (1048576)))
+  Write-Output("Free Memory:                   {0:###,###,###,###.0} GB" -f ($result.FreePhysicalMemory / (1048576)))
+
+  Write-Output(" ")
+  Write-Output("SYSTEM DRIVES")
+  Write-Output(" ")
+  Write-Output("DRIVE      VOLUME                           FREE           TOTAL")
+  Write-Output("-----      -------                  ------------    ------------")
+
+  $drives = Get-PSDrive | 
+       Where-Object {$_.Provider -Like "*\FileSystem"} |
+       Sort-Object -Property Name
+
+  $drives | ForEach-Object {Write-Output("{0} {1}  {2} GB {3} GB" -f 
+      ($_.Name + ":").PadRight(10, " "), 
+       $_.Description.PadRight(20, " "), 
+      ($_.Free / 1073741824).ToString("###,###,###,##0.0").PadLeft(12, " "), 
+      (($_.Free + $_.Used) / 1073741824).ToString("###,###,###,##0.0").PadLeft(12, " "))}
+
+  Get-CimInstance -ClassName win32_operatingsystem | select csname, lastbootuptime
+}

--- a/VSTS-Extensions/VSTSToolsListSystemInfo/listsysteminfo.ps1
+++ b/VSTS-Extensions/VSTSToolsListSystemInfo/listsysteminfo.ps1
@@ -1,6 +1,4 @@
-param (
-    [string]$debugonly
-)
+[string]$debugonly = $env:INPUT_DEBUGONLY
 
 Write-Verbose "Entering: listsysteminfo.ps1"
 Write-Verbose "  debugonly: $debugonly"

--- a/VSTS-Extensions/VSTSToolsListSystemInfo/task.json
+++ b/VSTS-Extensions/VSTSToolsListSystemInfo/task.json
@@ -37,7 +37,7 @@
     }
   ],
   "execution": {
-    "PowerShell": {
+    "PowerShell3": {
       "target": "$(currentDirectory)\\listsysteminfo.ps1",
       "argumentFormat": "",
       "workingDirectory": "$(currentDirectory)"

--- a/VSTS-Extensions/VSTSToolsListVariables/listvariables.ps1
+++ b/VSTS-Extensions/VSTSToolsListVariables/listvariables.ps1
@@ -1,6 +1,4 @@
-param (
-    [string]$debugonly
-)
+[string]$debugonly = $env:INPUT_DEBUGONLY
 
 Write-Verbose "Entering: listvariables.ps1"
 Write-Verbose "  debugonly = $debugonly"

--- a/VSTS-Extensions/VSTSToolsListVariables/listvariables.ps1
+++ b/VSTS-Extensions/VSTSToolsListVariables/listvariables.ps1
@@ -1,0 +1,14 @@
+param (
+    [string]$debugonly
+)
+
+Write-Verbose "Entering: listvariables.ps1"
+Write-Verbose "  debugonly = $debugonly"
+
+# Import the Task.Common dll that has all the cmdlets we need for Build
+import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
+
+if ($debugonly -eq "false" -or (($debugonly -eq "true") -and ($env:SYSTEM_DEBUG -eq "true")))
+{
+    (Get-ChildItem Env:).GetEnumerator() | % { Write-Host ("{0} = {1}" -f $_.key, $_.value) }
+}

--- a/VSTS-Extensions/VSTSToolsListVariables/task.json
+++ b/VSTS-Extensions/VSTSToolsListVariables/task.json
@@ -37,7 +37,7 @@
     }
   ],
   "execution": {
-    "PowerShell": {
+    "PowerShell3": {
       "target": "$(currentDirectory)\\listvariables.ps1",
       "argumentFormat": "",
       "workingDirectory": "$(currentDirectory)"

--- a/VSTS-Extensions/VSTSToolsStopBuild/stopbuild.ps1
+++ b/VSTS-Extensions/VSTSToolsStopBuild/stopbuild.ps1
@@ -1,0 +1,43 @@
+param (
+    [string]$leftOperand,
+    [string]$operator,
+    [string]$rightOperand
+)
+
+Write-Verbose "Entering: stopbuild.ps1"
+Write-Verbose "  leftOperand = $leftOperand"
+Write-Verbose "  operator = $operator"
+Write-Verbose "  rightOperand = $rightOperand"
+
+# Import the Task.Common dll that has all the cmdlets we need for Build
+import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
+
+switch($operator)
+{
+  "-eq" { $answer = ($leftOperand -eq $rightOperand) }
+  "-ne" { $answer = ($leftOperand -ne $rightOperand) }
+
+  "-lt" { $answer = ($leftOperand -lt $rightOperand) }
+  "-le" { $answer = ($leftOperand -le $rightOperand) }
+
+  "-gt" { $answer = ($leftOperand -gt $rightOperand) }
+  "-ge" { $answer = ($leftOperand -ge $rightOperand) }
+
+  "-Like" { $answer = ($leftOperand -Like $rightOperand) }
+  "-NotLike" { $answer = ($leftOperand -NotLike $rightOperand) }
+
+  "-Match" { $answer = ($leftOperand -Match $rightOperand) }
+  "-NotMatch" { $answer = ($leftOperand -NotMatch $rightOperand) }
+
+  "-Contains" { $answer = ($leftOperand -Contains $rightOperand) }
+  "-NotContains" { $answer = ($leftOperand -NotContains $rightOperand) }
+
+  "-In" { $answer = ($leftOperand -In $rightOperand) }
+  "-NotIn" { $answer = ($leftOperand -NotIn $rightOperand) }
+}
+
+if ($answer -eq $true)
+{
+    Write-Output("##vso[task.logissue type=warning;]Cancelling build based on currently selected criteria => $leftOperand $operator $rightOperand")
+    Write-Output("##vso[task.complete result=Cancelled;]")
+}

--- a/VSTS-Extensions/VSTSToolsStopBuild/stopbuild.ps1
+++ b/VSTS-Extensions/VSTSToolsStopBuild/stopbuild.ps1
@@ -1,8 +1,6 @@
-param (
-    [string]$leftOperand,
-    [string]$operator,
-    [string]$rightOperand
-)
+[string]$leftOperand = $env:INPUT_LEFTOPERAND
+[string]$operator = $env:INPUT_OPERATOR
+[string]$rightOperand = $env:INPUT_RIGHTOPERAND
 
 Write-Verbose "Entering: stopbuild.ps1"
 Write-Verbose "  leftOperand = $leftOperand"

--- a/VSTS-Extensions/VSTSToolsStopBuild/task.json
+++ b/VSTS-Extensions/VSTSToolsStopBuild/task.json
@@ -67,7 +67,7 @@
 
   ],
   "execution": {
-    "PowerShell": {
+    "PowerShell3": {
       "target": "$(currentDirectory)\\stopbuild.ps1",
       "argumentFormat": "",
       "workingDirectory": "$(currentDirectory)"


### PR DESCRIPTION
This PR aims at using the `PowerShell3` execution handler instead of the deprecated `PowerShell` one. This change requires to get arguments of the ps1 scripts differently (i.e. using `$env:INPUT_XXX` variables). I didn't identify anything else to patch given the tasks logic. See https://github.com/microsoft/azure-pipelines-task-lib/tree/master/powershell for more details.

A more robust way to go would be to directly rely on [VstsTaskSdk module](https://www.powershellgallery.com/packages/VstsTaskSdk). But this would require either to commit and push this module for each task or to restore it on the fly when building the extension (both locally and in the CI).

NB: ps1 files were removed in a previous commit (mistake?). I reverted this in order to patch the scripts.

Fixes #12.